### PR TITLE
Update utils.py to solve error when cos_norm_out = False

### DIFF
--- a/mnnpy/utils.py
+++ b/mnnpy/utils.py
@@ -80,6 +80,8 @@ def transform_input_data(datas, cos_norm_in, cos_norm_out, var_index, var_subset
                     out_batches = p_n.starmap(scale_rows, zip(datas, out_scaling))
             else:
                 out_batches = [scale_rows(a,b) for (a,b) in zip(datas, out_scaling)]
+    else: 
+        out_batches = datas
     return in_batches, out_batches, var_sub_index, same_set
 
 


### PR DESCRIPTION
Added one line to assign datas (non-normalized) to out_batches if cos_norm_out is set to False. (In the original code, out_batches would not be defined if cos_norm_out was set to False, resulting in an error later on.) I compared with the MNN code in R to make sure this was the correct definition of out_batches.