### PR TITLE
added instructions for an installation fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,12 @@ cd mnnpy
 pip install .
 ```
 
-Note: It is possible that simply running `pip install .` or `pip install mnnpy` may not work to install mnnpy, depending on which C compiler is being used on the system. If this occurs, and you are running a Linux/MacOS system, run this instead:
+Note: It is possible that simply running `pip install .` or `pip install mnnpy` may not work to install mnnpy, depending on which C compiler is being used on the system. If this occurs, and you are running a Linux/MacOS system, first ensure that you have `python3-dev` installed:
+```
+sudo apt-get install python3-dev  # Linux with apt-get
+```
+
+If errors persist, run this instead:
 ```
 brew install gcc@8
 export CC=/usr/local/Cellar/gcc@8/8.4.0/bin/gcc-8


### PR DESCRIPTION
I ran into installation errors; the installation errors were entirely fixed by installing python3-dev. I don't know whether it'll fix the other reported installation problems. Might address #46, #18.